### PR TITLE
Fix command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To test the development of the library:
    npm ci
 
    # Second run the server in dev mode
-   num run dev
+   npm run dev
    ```
 
 The server has the dependency to the lib as a folder link, which means that it


### PR DESCRIPTION
## Summary
- fix a typo in README instructions so `npm run dev` works

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840bcf5eeec832d97cd42ca54a5ff68