### PR TITLE
Add simple Jest unit tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,12 +2,15 @@ import type { Config } from "jest";
 
 const config: Config = {
   verbose: true,
-  preset: "ts-jest",
+  preset: "ts-jest/presets/default-esm",
   testEnvironment: "node",
-  transform: {
-    "^.+\\.(j|t)sx?$": "ts-jest",
+  extensionsToTreatAsEsm: [".ts", ".tsx"],
+  transformIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/dist/"] ,
+  globals: {
+    "ts-jest": {
+      useESM: true,
+    },
   },
-  // transformIgnorePatterns: ["<rootDir>/node_modules/"],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rollup -c",
     "prepublish": "npm run build",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "peerDependencies": {
     "@react-pdf/renderer": "3.4.4",

--- a/src/__tests__/Markdown.test.tsx
+++ b/src/__tests__/Markdown.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View } from '@react-pdf/renderer';
+import { Markdown } from '../index';
+
+describe('Markdown component', () => {
+  test('wraps converted markdown in a View', () => {
+    const element = Markdown({ md: 'Hello' });
+    expect(React.isValidElement(element)).toBe(true);
+    expect(element.type).toBe(View);
+  });
+});

--- a/src/__tests__/markdownToReactPDF.test.tsx
+++ b/src/__tests__/markdownToReactPDF.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Image, Text } from '@react-pdf/renderer';
+// Import Markdown component from compiled dist to avoid ESM issues
+import { Markdown } from '../index';
+
+describe('markdownToReactPDF', () => {
+  test('converts heading and paragraph', () => {
+    const md = '# Title\n\nSome text';
+    const element = Markdown({ md });
+    expect(React.isValidElement(element)).toBe(true);
+  });
+
+  test('renders images', () => {
+    const md = '![](http://example.com/test.png)';
+    const element = Markdown({ md });
+    expect(React.isValidElement(element)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest for ESM and VM modules
- provide basic unit tests for Markdown component
- add minimal Markdown conversion tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841851d0394832d81031910c3ca0d9e