### PR TITLE
Add local coverage badge

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"coverage","message":"37.5%","color":"red"}

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,35 @@
+name: Test and update coverage badge
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Remove dist directory
+        run: rm -rf dist
+      - name: Run tests with coverage
+        run: npm test -- --coverage --coverageReporters="text-summary" --coverageReporters="json-summary"
+      - name: Generate coverage badge
+        run: node scripts/generateCoverageBadge.cjs
+      - name: Commit coverage badge
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .github/badges/coverage.json
+          if git commit -m "chore: update coverage badge"; then
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # react-md2pdf
+[![build status](https://github.com/proppex/react-md2pdf/actions/workflows/main.yml/badge.svg)](https://github.com/proppex/react-md2pdf/actions/workflows/main.yml) [![coverage status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/proppex/react-md2pdf/main/.github/badges/coverage.json)](https://raw.githubusercontent.com/proppex/react-md2pdf/main/.github/badges/coverage.json)
 
 We are creating a react module to parse a Markdown formatted text into PDF using the [react-pdf](https://react-pdf.org/) library.
 

--- a/scripts/generateCoverageBadge.cjs
+++ b/scripts/generateCoverageBadge.cjs
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const summaryPath = 'coverage/coverage-summary.json';
+if (!fs.existsSync(summaryPath)) {
+  console.error('Coverage summary not found');
+  process.exit(1);
+}
+const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+const pct = summary.total.lines.pct;
+function colorFor(pct) {
+  if (pct >= 90) return 'brightgreen';
+  if (pct >= 80) return 'green';
+  if (pct >= 70) return 'yellowgreen';
+  if (pct >= 60) return 'yellow';
+  if (pct >= 50) return 'orange';
+  return 'red';
+}
+const badge = {
+  schemaVersion: 1,
+  label: 'coverage',
+  message: pct + '%',
+  color: colorFor(pct)
+};
+fs.mkdirSync('.github/badges', { recursive: true });
+fs.writeFileSync('.github/badges/coverage.json', JSON.stringify(badge));


### PR DESCRIPTION
## Summary
- generate a JSON badge for coverage
- create workflow to update the badge on pushes
- show the badge in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418a5af888832db5ed4c63e8517e71